### PR TITLE
Add option to compute confidence intervals

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ matplotlib~=3.3.4
 segeval~=2.0.11
 sacremoses~=0.0.46
 srt~=3.5.0
+numpy


### PR DESCRIPTION
# Why is the change needed?

Computing statistical significance is an important feature to ensure the statistical soundness of conclusions.
Unfortunately, sigma lacks the possibility to compute any statistical significance test.

# What does the path do?

This patch introduces confidence interval (CI) computation for BLEU and Sigma by leveraging bootstrap resampling and the CI computation of SacreBLEU.

# How was this patch tested?

Manual runs with and without the new change. E.g. of the outputs:

```
(venv) mgaido@Marcos-MacBook-Pro TACL2023Subtilting % python EvalSubtitle/evalsub_main.py -e2e -ref EC/de/ref/all.blocks -sys  EC/de/direct/all.blocks.resegm -ci -res x
Computing the following metrics: BLEU_nb, BLEU_br, TER_br, Sigma, CPL_conf
Evaluating EC/de/direct/all.blocks.resegm
CPL conformity: 81.28%
BLEU_br: 22.31 (μ = 22.27 ± 1.69)
BLEU_nb: 25.31 (μ = 25.29 ± 1.90)
Sigma: 70.82 (μ = 70.72 ± 2.41)
nrefs:1|case:lc|tok:tercom|norm:no|punct:yes|asian:no|version:2.0.0
TER_br: 22.08
Writing results to csv file: x
(venv) mgaido@Marcos-MacBook-Pro TACL2023Subtilting % python EvalSubtitle/evalsub_main.py -e2e -ref EC/de/ref/all.blocks -sys  EC/de/direct/all.blocks.resegm -res x    
Computing the following metrics: BLEU_br, BLEU_nb, TER_br, Sigma, CPL_conf
Evaluating EC/de/direct/all.blocks.resegm
CPL conformity: 81.28%
BLEU_br: 22.31
BLEU_nb: 25.31
Sigma: 70.82
nrefs:1|case:lc|tok:tercom|norm:no|punct:yes|asian:no|version:2.0.0
TER_br: 22.08
Writing results to csv file: x
```